### PR TITLE
Refactoring of Project Management for the current-proj page

### DIFF
--- a/nfabackend/src/main/java/com/msg/nfabackend/resources/ProjectResource.java
+++ b/nfabackend/src/main/java/com/msg/nfabackend/resources/ProjectResource.java
@@ -71,4 +71,10 @@ public class ProjectResource {
 		return queryService.findProject(status,lookupCustName);
 	}
 	
+	@GET
+	@Path("/{ProjectId}")
+	public Project getProject(@PathParam("ProjectId") Long id) {
+		return queryService.getProject(id);
+	}
+	
 } 

--- a/nfabackend/src/main/java/com/msg/nfabackend/services/QueryService.java
+++ b/nfabackend/src/main/java/com/msg/nfabackend/services/QueryService.java
@@ -29,6 +29,10 @@ public class QueryService {
 	public List<Project> getAllProject() {
 		return em.createQuery("from Project", Project.class).getResultList();
 	}
+	
+	public Project getProject(Long projectId) {
+		return em.createQuery("from Project WHERE id IS " + projectId, Project.class).getSingleResult();
+	}
 
 	public List<Project> findProject(String status, String lookupCustName) {
 		CriteriaBuilder criteriaBuilder = em.getCriteriaBuilder();

--- a/nfafrontend/src/app/app-routing.module.ts
+++ b/nfafrontend/src/app/app-routing.module.ts
@@ -30,9 +30,9 @@ const appRoutes: Routes = [
     ]}
   ]},
   {path: 'home', component: HomeComponent, canActivate: [AuthGuard]},
-  {path:  'curr-projects/:id/edit/nfa', component: NfacatalogComponent, canActivate: [AuthGuard], children:[
+  {path:  'curr-projects/:project_id/edit/nfa', component: NfacatalogComponent, canActivate: [AuthGuard], children:[
       {path: '', component: NfacatalogListComponent},
-      {path: ':id', component: NfacatalogCriteriaComponent, canActivate: [AuthGuard], children: [
+      {path: ':project_id', component: NfacatalogCriteriaComponent, canActivate: [AuthGuard], children: [
           {path: ':criteria_id', component: NfacatalogMetricComponent},
           {path: ':criteria_id/:metric_id', component: NfacatalogNfaComponent}
         ]}
@@ -41,7 +41,7 @@ const appRoutes: Routes = [
 
   {path:  'curr-projects/new/nfa', component: NfacatalogComponent, canActivate: [AuthGuard], children:[
       {path: '', component: NfacatalogListComponent},
-      {path: ':id', component: NfacatalogCriteriaComponent, canActivate: [AuthGuard], children: [
+      {path: ':project_id', component: NfacatalogCriteriaComponent, canActivate: [AuthGuard], children: [
           {path: ':criteria_id', component: NfacatalogMetricComponent},
           {path: ':criteria_id/:metric_id', component: NfacatalogNfaComponent}
         ]}
@@ -49,9 +49,9 @@ const appRoutes: Routes = [
     ]},
   {path: 'curr-projects', component: CurrentProjectComponent, canActivate: [AuthGuard], children: [
     {path:  'new', component: ProjectEditComponent},
-    {path: ':id', component: ProjectDetailComponent},
-    {path: ':id/edit', component: ProjectEditComponent},
-    {path: ':id/edit/stakeholder', component: StakeHolderComponent}
+    {path: ':project_id', component: ProjectDetailComponent},
+    {path: ':project_id/edit', component: ProjectEditComponent},
+    {path: ':project_id/edit/stakeholder', component: StakeHolderComponent}
   ]},
   // otherwise redirect to home
   { path: '**', redirectTo: '' }

--- a/nfafrontend/src/app/current-project/assign-nfa/choose-nfa/choose-nfa.component.ts
+++ b/nfafrontend/src/app/current-project/assign-nfa/choose-nfa/choose-nfa.component.ts
@@ -55,7 +55,7 @@ export class ChooseNfaComponent implements OnInit {
   }
 
   isAlreadyAdded(nfa: NfaCatalogModel){
-    const referProjectNfas = this.currentProjectService.getProject(this.id).projectNfas;
+    const referProjectNfas = this.currentProjectService.getProjectById(this.id).projectNfas;
     let flag = false;
     referProjectNfas.forEach((x) => {
       if (x.nfaCatalogId === nfa.nfaCatalogId) {flag = true;}
@@ -91,7 +91,7 @@ export class ChooseNfaComponent implements OnInit {
   }
 
   onAddOrRemove(nfa: NfaCatalogModel){
-    const editedProject = this.currentProjectService.getProject(this.id);
+    const editedProject = this.currentProjectService.getProjectById(this.id);
     const ind = editedProject.projectNfas.findIndex((x) => x.nfaCatalogId === nfa.nfaCatalogId)
     if (ind !== -1) {
       editedProject.projectNfas.splice(ind,1);

--- a/nfafrontend/src/app/current-project/assign-nfa/nfa-list/nfa-list.component.ts
+++ b/nfafrontend/src/app/current-project/assign-nfa/nfa-list/nfa-list.component.ts
@@ -29,9 +29,9 @@ export class NfaListComponent implements OnInit , OnDestroy{
       .subscribe(
         (params: Params) => {
           this.id = +params['id'];
-          this.project = this.currentProjectService.getProject(this.id);
+          this.project = this.currentProjectService.getProjectById(this.id);
           this.currentProjectService.setSelectedProjectId(this.id);
-          this.nfaCatalogs = this.currentProjectService.getProject(this.id).projectNfas;
+          this.nfaCatalogs = this.currentProjectService.getProjectById(this.id).projectNfas;
         }
       );
 
@@ -52,7 +52,7 @@ export class NfaListComponent implements OnInit , OnDestroy{
   }
 
   onAddOrRemove(nfa: NfaCatalogModel){
-    const editedProject = this.currentProjectService.getProject(this.id);
+    const editedProject = this.currentProjectService.getProjectById(this.id);
     const ind = editedProject.projectNfas.findIndex((x) => x.nfaCatalogId === nfa.nfaCatalogId)
     if (ind !== -1) {
       editedProject.projectNfas.splice(ind,1);

--- a/nfafrontend/src/app/current-project/current-project.service.ts
+++ b/nfafrontend/src/app/current-project/current-project.service.ts
@@ -4,21 +4,34 @@ import {ProjectType} from '../shared/type.model';
 import {Stakeholder} from '../shared/stakeholder.model';
 
 
-
 export class CurrentProjectService {
+
   projectsChanged = new Subject<Project[]>();
-  private projects: Project[];
+  private projectsSubset: Project[];
   private types: ProjectType[];
   private selectedProjectId: number;
   private project : Project;
-  private  nfaMode : boolean;
+  private nfaMode : boolean;
+  private status : string;
 
   getProjects() {
-    return this.projects.slice();
+    return this.projectsSubset.slice();
   }
 
-  getProject(index: number) {
-    return this.projects[index];
+  getProjectById(projectId: number) : Project {
+    for(let index in this.projectsSubset) {
+
+      if (this.projectsSubset[index].id == projectId) {
+
+        return this.projectsSubset[index];
+      }
+    }
+    console.error("Project with Id " + projectId + " is not Part of the current Subset");
+    return null;
+  }
+
+  getProject() : Project {
+    return this.project;
   }
 
   getProjectWithNoId(){
@@ -29,24 +42,36 @@ export class CurrentProjectService {
     this.project = proj;
   }
 
+  setProjectById(projId: number){
+    this.project = this.getProjectById(projId);
+  }
+
   addProject(project: Project) {
-    this.projects.push(project);
-    this.projectsChanged.next(this.projects.slice());
+    this.projectsSubset.push(project);
+    this.projectsChanged.next(this.projectsSubset.slice());
   }
 
-  updateProject(index: number, newProject: Project) {
-    this.projects[index] = newProject;
-    this.projectsChanged.next(this.projects.slice());
+  updateProject(id: number, newProject: Project) {
+    for(let index in this.projectsSubset){
+      if(this.projectsSubset[index].id == id){
+        this.projectsSubset[index] = newProject;
+      }
+    }
+    this.projectsChanged.next(this.projectsSubset.slice());
   }
 
-  deleteProject(index: number) {
-    this.projects.splice(index,1);
-    this.projectsChanged.next(this.projects.slice());
+  deleteProjectById(id: number) {
+    for(let index in this.projectsSubset){
+      if(this.projectsSubset[index].id == id){
+        this.projectsSubset.splice(Number(index),1);
+      }
+    }
+    this.projectsChanged.next(this.projectsSubset.slice());
   }
 
   setProjects(projects: Project[]){
-    this.projects = projects;
-    this.projectsChanged.next(this.projects.slice());
+    this.projectsSubset = projects;
+    this.projectsChanged.next(this.projectsSubset.slice());
   }
 
   setSelectedProjectId(index: number){
@@ -56,7 +81,7 @@ export class CurrentProjectService {
     return this.selectedProjectId;
   }
   getNfa(index: number){
-    return this.projects[this.selectedProjectId].projectNfas[index];
+    return this.projectsSubset[this.selectedProjectId].projectNfas[index];
   }
 
   getTypes() {
@@ -68,9 +93,16 @@ export class CurrentProjectService {
   }
 
   updateStakeholder(index: number, stakeholder: Stakeholder[]) {
-    this.projects[index].projectStakeholders = stakeholder;
-    this.projectsChanged.next(this.projects.slice());
+    this.projectsSubset[index].projectStakeholders = stakeholder;
+    this.projectsChanged.next(this.projectsSubset.slice());
   }
 
+  getStatus(): string {
+    return this.status;
+  }
+
+  setStatus(value: string) {
+    this.status = value;
+  }
 
 }

--- a/nfafrontend/src/app/current-project/project-detail/project-detail.component.ts
+++ b/nfafrontend/src/app/current-project/project-detail/project-detail.component.ts
@@ -4,8 +4,7 @@ import {DataStorageService} from '../../shared/data-storage.service';
 import {Project} from '../../shared/project.model';
 import {Stakeholder} from '../../shared/stakeholder.model'
 import {CurrentProjectService} from '../current-project.service';
-import {Response} from '@angular/http';
-import { LocalStorageService, SessionStorageService, LocalStorage, SessionStorage } from 'angular-web-storage';
+import { LocalStorageService } from 'angular-web-storage';
 
 @Component({
   selector: 'app-project-detail',
@@ -15,7 +14,7 @@ import { LocalStorageService, SessionStorageService, LocalStorage, SessionStorag
 export class ProjectDetailComponent implements OnInit {
   project: Project;
   name: string;
-  id: number;
+  project_id_param: number;
   isSelected:boolean;
   selectedStakeHolders: Stakeholder[];
   selectedStake:number[];
@@ -36,12 +35,13 @@ export class ProjectDetailComponent implements OnInit {
     this.route.params
       .subscribe(
         (params: Params) => {
-          this.id = +params['id'];
-          this.project = this.currentProjectService.getProject(this.id);
+          this.project_id_param = +params['project_id'];
+
+          this.project = this.currentProjectService.getProjectById(this.project_id_param);
+
           this.stackHolders = this.project.projectStakeholders.slice();
           this.selectedStakeHolders = this.stackHolders;
         }
-
 
       );
   }
@@ -53,14 +53,14 @@ export class ProjectDetailComponent implements OnInit {
 
   onDeleteProject() {
   this.local.clear();
-  this.currentProjectService.deleteProject(this.id);
-    this.dataStorageService.deleteProject(this.project)
-      .subscribe(
-        (response) => {
-          this.router.navigate(['../'], {relativeTo: this.route});
-          this.currentProjectService.projectsChanged.next(this.currentProjectService.getProjects());
-        }
-      );
+  this.currentProjectService.deleteProjectById(this.project_id_param);
+  this.dataStorageService.deleteProject(this.project)
+    .subscribe(
+      (response) => {
+        this.router.navigate(['../'], {relativeTo: this.route});
+        this.currentProjectService.projectsChanged.next(this.currentProjectService.getProjects());
+      }
+    );
   }
   // Getting Selected stackholder
   getSelected() {

--- a/nfafrontend/src/app/current-project/project-list/project-item/project-item.component.html
+++ b/nfafrontend/src/app/current-project/project-list/project-item/project-item.component.html
@@ -1,5 +1,5 @@
 <a class="list-group-item clearfix"
-   [routerLink] = "[index]"
+   [routerLink] = "[id]"
    routerLinkActive="active"
    style="cursor: pointer;"
   >

--- a/nfafrontend/src/app/current-project/project-list/project-item/project-item.component.ts
+++ b/nfafrontend/src/app/current-project/project-list/project-item/project-item.component.ts
@@ -1,19 +1,29 @@
 import {Component, Input, OnInit} from '@angular/core';
 import {Project} from '../../../shared/project.model';
+import {CurrentProjectService} from "../../current-project.service";
 
 @Component({
   selector: 'app-project-item',
   templateUrl: './project-item.component.html',
   styleUrls: ['./project-item.component.css']
 })
-export class ProjectItemComponent implements OnInit {
+export class ProjectItemComponent implements OnInit{
 
+  // @Input() index: number;
   @Input() project: Project;
-  @Input() index: number;
+  @Input() id: number;
 
-  constructor() { }
+  constructor(
+    private currentProjectService: CurrentProjectService
+  ) {
+    this.currentProjectService.setProject(this.project);
+  }
 
   ngOnInit() {
+    // this.project = this.currentProjectService.getProjectById(this.id);
+    // this.id = this.project.id;
+
   }
+
 
 }

--- a/nfafrontend/src/app/current-project/project-list/project-list.component.html
+++ b/nfafrontend/src/app/current-project/project-list/project-list.component.html
@@ -21,7 +21,7 @@
     <div class="col-xs-6 text-center"><label for="filter" class="small">{{ 'nfa.search-project.filter' | translate }}:</label> </div>
     <div class="col-xs-6 btn-group pull-left">
       <button type="button" id="filter" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-        {{this.getStringByStatus(status)}} <span class="caret"></span>
+        {{ getStringByStatus( status) }} <span class="caret"></span>
       </button>
       <ul class="dropdown-menu">
         <li><a (click)="onAll(inp)">{{ 'nfa.search-project.filter-all' | translate }}</a></li>
@@ -37,6 +37,6 @@
     <app-project-item
       *ngFor="let projectEl of projects let i = index"
       [project]="projectEl"
-      [index]="i"></app-project-item>
+      [id]="projectEl.id"></app-project-item>
   </div>
 </div>

--- a/nfafrontend/src/app/current-project/project-list/project-list.component.ts
+++ b/nfafrontend/src/app/current-project/project-list/project-list.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, OnInit} from '@angular/core';
+import {Component, Input, OnChanges, OnInit, SimpleChanges} from '@angular/core';
 import {DataStorageService} from '../../shared/data-storage.service';
 import {Project} from '../../shared/project.model';
 import {Response} from '@angular/http';
@@ -7,7 +7,7 @@ import {ProjectType} from '../../shared/type.model';
 import {ActivatedRoute, Router} from '@angular/router';
 import {Subscription} from 'rxjs/Subscription';
 import {TranslateService} from "@ngx-translate/core";
-import { LocalStorageService, SessionStorageService, LocalStorage, SessionStorage } from 'angular-web-storage';
+import { LocalStorageService } from 'angular-web-storage';
 
 enum STATUS {
   ALL = 'All',
@@ -21,9 +21,8 @@ enum STATUS {
   styleUrls: ['./project-list.component.css']
 })
 
-export class ProjectListComponent implements OnInit {
+export class ProjectListComponent implements OnInit{
 
-  status = STATUS.ON_PROCESS;
   projects: Project[];
   subscription: Subscription;
 
@@ -32,11 +31,14 @@ export class ProjectListComponent implements OnInit {
               private router: Router,
               private dataStorageService: DataStorageService,
               private tranlateService: TranslateService,
-              private  local: LocalStorageService) { }
+              private  local: LocalStorageService)
+  {
+    this.currentProjectService.setStatus(STATUS.ON_PROCESS);
+  }
 
 
   ngOnInit() {
-    this.dataStorageService.getProjectByName(this.status,"")
+    this.dataStorageService.getProjectByName(this.currentProjectService.getStatus(),"")
       .subscribe(
         (response: Response) => {
                    const projects: Project[] = response.json();
@@ -59,9 +61,10 @@ export class ProjectListComponent implements OnInit {
       );
   }
 
+
   onSearch(frominput: HTMLInputElement) {
 
-    this.dataStorageService.getProjectByName(this.status,frominput.value).subscribe(
+    this.dataStorageService.getProjectByName(this.currentProjectService.getStatus(),frominput.value).subscribe(
       (response: Response) => {
         const projects: Project[] = response.json();
         this.projects = projects;
@@ -78,29 +81,29 @@ export class ProjectListComponent implements OnInit {
 
   onAll(frominput: HTMLInputElement) {
 
-    if(STATUS.ALL != this.status){
+    if(STATUS.ALL != this.currentProjectService.getStatus()){
       this.router.navigate([this.route.snapshot.routeConfig.path]);
     }
-    this.status = STATUS.ALL;
+    this.currentProjectService.setStatus( STATUS.ALL);
 
-    this.dataStorageService.getProjectByName(this.status,frominput.value)
+    this.dataStorageService.getProjectByName(this.currentProjectService.getStatus(),frominput.value)
       .subscribe(
         (response: Response) => {
           const projects: Project[] = response.json();
           this.projects = projects;
-          this.currentProjectService.setProjects(this.projects)
+          this.currentProjectService.setProjects(this.projects);
 
         }
       );
   }
 
   onProcess(frominput: HTMLInputElement) {
-    if(STATUS.ON_PROCESS != this.status) {
+    if(STATUS.ON_PROCESS != this.currentProjectService.getStatus()) {
       this.router.navigate([this.route.snapshot.routeConfig.path]);
-      this.status = STATUS.ON_PROCESS;
+      this.currentProjectService.setStatus( STATUS.ON_PROCESS);
     }
 
-    this.dataStorageService.getProjectByName(this.status,frominput.value)
+    this.dataStorageService.getProjectByName(this.currentProjectService.getStatus(),frominput.value)
       .subscribe(
         (response: Response) => {
           const projects: Project[] = response.json();
@@ -110,12 +113,12 @@ export class ProjectListComponent implements OnInit {
       );
   }
   onArchived(frominput: HTMLInputElement) {
-    if(STATUS.ARCHIVED != this.status){
+    if(STATUS.ARCHIVED != this.currentProjectService.getStatus()){
       this.router.navigate([this.route.snapshot.routeConfig.path]);
-      this.status = STATUS.ARCHIVED;
+      this.currentProjectService.setStatus( STATUS.ARCHIVED);
     }
 
-    this.dataStorageService.getProjectByName(this.status,frominput.value)
+    this.dataStorageService.getProjectByName(this.currentProjectService.getStatus(),frominput.value)
       .subscribe(
         (response: Response) => {
           const projects: Project[] = response.json();
@@ -125,8 +128,8 @@ export class ProjectListComponent implements OnInit {
     );
   }
 
-  getStringByStatus(status : STATUS) : string{
-
+  getStringByStatus() : string {
+    let status : string = this.currentProjectService.getStatus();
     let retVal :string = '';
     switch (status){
       case STATUS.ON_PROCESS:
@@ -145,4 +148,6 @@ export class ProjectListComponent implements OnInit {
 
     return retVal;
   }
+
+
 }

--- a/nfafrontend/src/app/current-project/stake-holder/stake-holder.component.html
+++ b/nfafrontend/src/app/current-project/stake-holder/stake-holder.component.html
@@ -3,7 +3,7 @@
     <form [formGroup]="projectForm" (ngSubmit)="onSubmit()">
       <div class= "row">
         <div class= "col-xs-12">
-          <button type="submit" class="btn btn-success" [disabled]="!projectForm.valid"> <span class="glyphicon glyphicon-floppy-disk"> </span> Save</button>
+          <button type="submit" class="btn btn-success" [disabled]="!projectForm.valid"> <span class="glyphicon glyphicon-floppy-disk"> </span> {{'nfa.save' | translate}}</button>
           <button type="button" class="btn btn-danger" (click)="onCancel()">{{ 'nfa.factor' | translate }}</button>
         </div>
       </div>

--- a/nfafrontend/src/app/current-project/stake-holder/stake-holder.component.ts
+++ b/nfafrontend/src/app/current-project/stake-holder/stake-holder.component.ts
@@ -29,8 +29,8 @@ export class StakeHolderComponent implements OnInit {
     this.route.params
       .subscribe(
         (params: Params) => {
-          this.id = +params['id'];
-          this.editMode = params['id'] != null;
+          this.id = +params['project_id'];
+          this.editMode = params['project_id'] != null;
           //this.initForm();
 
           this.dataStorageService.getNfaFactor()
@@ -47,7 +47,7 @@ export class StakeHolderComponent implements OnInit {
 
   /*onSubmit() {
 
-    const newProject = this.currentProjectService.getProject(this.id);
+    const newProject = this.currentProjectService.getProjectById(this.project_id_param);
     newProject.projectStakeholders = this.projectForm.value['projectStakeholders'];
     for (let i = 0; i < newProject.projectStakeholders.length; i++) {
       for (let j = 0; j < newProject.projectStakeholders[i].stakeholderFactors.length; j++){
@@ -57,7 +57,7 @@ export class StakeHolderComponent implements OnInit {
         });
       }
     }
-    this.currentProjectService.updateProject(this.id, newProject);
+    this.currentProjectService.updateProject(this.project_id_param, newProject);
     this.dataStorageService.updateProject(newProject)
       .subscribe(
         (response: Response) => {
@@ -106,7 +106,7 @@ export class StakeHolderComponent implements OnInit {
 
 
     if (this.editMode) {
-      const project = this.currentProjectService.getProject(this.id);
+      const project = this.currentProjectService.getProjectById(this.project_id_param);
       if(project['projectStakeholders']) {
         for(const stakeholder of project.projectStakeholders) {
 

--- a/nfafrontend/src/app/nfacatalog/nfacatalog-criteria/nfacatalog-nfa/nfacatalog-nfa.component.ts
+++ b/nfafrontend/src/app/nfacatalog/nfacatalog-criteria/nfacatalog-nfa/nfacatalog-nfa.component.ts
@@ -65,7 +65,7 @@ export class NfacatalogNfaComponent implements OnInit {
     this.route.parent.parent.params.subscribe(params => this.projectId = params['id']);
     if (this.projectId != null) {
       this.nfaCatalogService.projectId = this.projectId;
-      this.projectNfs = this.currentProjectService.getProject(this.projectId).projectNfas.slice();
+      this.projectNfs = this.currentProjectService.getProjectById(this.projectId).projectNfas.slice();
     }
     this.projectMode = this.local.get('nfaMode');
   }

--- a/nfafrontend/src/app/nfacatalog/nfacatalog-list/nfacatalog-list.component.ts
+++ b/nfafrontend/src/app/nfacatalog/nfacatalog-list/nfacatalog-list.component.ts
@@ -48,7 +48,7 @@ export class NfacatalogListComponent implements OnInit {
         }
       );
     this.project = this.local.get('currProject');
-    this.projectNfs = this.currentProjectService.getProject(this.project.id).projectNfas.slice();
+    this.projectNfs = this.currentProjectService.getProjectById(this.project.id).projectNfas.slice();
     if (this.project.id != null && this.local.get('selNfs') == null ){
       this.local.set('selNfs', this.projectNfs );
     }

--- a/nfafrontend/src/app/shared/data-storage.service.ts
+++ b/nfafrontend/src/app/shared/data-storage.service.ts
@@ -4,6 +4,7 @@ import {Project} from './project.model';
 import {HttpParams} from '@angular/common/http';
 import {NfaCatalogModel} from './nfaCatalog.model';
 import {Stakeholder} from './stakeholder.model';
+import {Observable} from "rxjs/Observable";
 
 
 
@@ -14,7 +15,6 @@ export class DataStorageService {
   constructor(private http: Http) {}
 
   storeNfa(metricId: number, nfa: NfaCatalogModel) {
-    console.log(nfa);
    return this.http.post('http://localhost:8080/nfabackend/webapi/nfa_catalog/create/' + metricId, nfa);
   }
   storeProject(newproject: Project) {
@@ -40,6 +40,10 @@ export class DataStorageService {
 
   getProjectByName(status: string, param: string ) {
    return this.http.get('http://localhost:8080/nfabackend/webapi/project/search?status=' + status +'&lookupCustName=' + param );
+  }
+
+  getProjectById(projectId: number){
+    return this.http.get('http://localhost:8080/nfabackend/webapi/project/' + projectId);
   }
 
   getTypes() {


### PR DESCRIPTION
While trying to access the Project ID I realised, that we only use the counting Indices from displaying the list as Identification.
Not the actual Id. That results in mistakes, when deleting or editing stuff.
So I startet to repair it briefly. 5h later im done.
The following has changed:

- Use Project IDs in URL instead of counting index -> unique identifier
- refactored backend to query single Projects -> we could not do this yet.
- all Projects Operations now work with the "ID" as Identifier -> delete the correct project.

